### PR TITLE
fix: corrects nextConfig use

### DIFF
--- a/next-webpack-compression.js
+++ b/next-webpack-compression.js
@@ -4,7 +4,7 @@ const CompressionPlugin = require('compression-webpack-plugin');
 const zlib = require('zlib');
 const mimeDb = require('mime-db');
 
-module.exports = (nextConfig = {}) => ({
+module.exports = () => (nextConfig = {}) => ({
     ...nextConfig,
     webpack(config, options) {
         const compressibleRegExps = Object

--- a/test/next-wepack-compression.test.js
+++ b/test/next-wepack-compression.test.js
@@ -26,26 +26,26 @@ afterEach(() => {
 });
 
 it('should return the same config object that is passed', () => {
-    const result = withCompression().webpack(config, {});
+    const result = withCompression()().webpack(config, {});
 
     expect(result).toBe(config);
 });
 
 it('should push compression settings to webpack config', () => {
-    withCompression().webpack(config, {});
+    withCompression()().webpack(config, {});
 
     expect(config).toMatchSnapshot();
 });
 
 it('should return a function if nextConfig is a function', () => {
-    const result = withCompression(nextConfig).webpack(config, {});
+    const result = withCompression()(nextConfig).webpack(config, {});
 
     expect(nextConfig.webpack).toHaveBeenCalledTimes(1);
     expect(nextConfig.webpack).toHaveReturnedWith(result);
 });
 
 it('should push the passed object to the config and call next function', () => {
-    const result = withCompression({ foo: 'bar' });
+    const result = withCompression()({ foo: 'bar' });
 
     expect(result).toMatchObject({ foo: 'bar' });
     expect(typeof result.webpack).toBe('function');
@@ -54,7 +54,7 @@ it('should push the passed object to the config and call next function', () => {
 it('should not push brotli compression plugin if brotli compression is not available', () => {
     delete zlib.brotliCompress;
 
-    withCompression().webpack(config, {});
+    withCompression()().webpack(config, {});
 
     expect(config).toMatchSnapshot();
 });


### PR DESCRIPTION
This PR fixes access to nextConfig. This fix is necessary so that this plugin can be called at any point other than the very end of the webpack configuration.