### PR TITLE
fix: disable etag

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ All options from [serve-static](https://www.npmjs.com/package/serve-static) are 
 {
     maxAge: 365 * 24 * 60 * 60 * 1000, // 1 year
     immutable: true,
+    etag: false,
     index: false // Can't be changed
 }
 ```

--- a/express-middleware.js
+++ b/express-middleware.js
@@ -22,6 +22,7 @@ const preCompression = (app, options = {}) => {
     options = {
         maxAge: 365 * 24 * 60 * 60 * 1000, // 1 year
         immutable: true,
+        etag: false,
         ...options,
         index: false,
     };

--- a/test/express-middleware.test.js
+++ b/test/express-middleware.test.js
@@ -103,6 +103,19 @@ it('should use throw an error if used in dev', () => {
     }).toThrow(/should only be called in production/);
 });
 
+it('should respond with the correct default headers', async () => {
+    const server = express();
+
+    server.use(preCompressionMiddleware(NEXT_APP));
+
+    await request(server)
+    .get(`${NEXT_STATIC_FOLDER}/test.txt`)
+    .expect('Cache-Control', 'public, max-age=31536000, immutable')
+    .expect((res) => {
+        expect(res.headers.etag).toBe(undefined);
+    });
+});
+
 it('should forward options to serve-static', async () => {
     const server = express();
 


### PR DESCRIPTION
ETag is not necessary since we are issue a cache-control header to cache for 1 year and flagging it as immutable.